### PR TITLE
keytab.py : allow file import of multiple secrets from impacket secretsdump output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ And part two: <https://dirkjanm.io/active-directory-forest-trusts-part-two-trust
 Reads a TGT or TGS (TGS requires manual changes in the source code) and decrypts this using the NT hash or Kerberos key you put in the source code. It will print the PAC inside your ticket. Then it will request an ST for the specified SPN, at the DC you specify. It will decrypt this and print the PAC, then store it in a file.
 
 ## keytab.py
+
 Contains impacket compatible structures for keytab files. Allows you to write AES/RC4 keys to a keytab file, which can be loaded into Wireshark to automatically decrypt the encrypted parts of Kerberos exchanges. Great for debugging.
+It takes input straight from impacket secetsdump.py, i.e. a file with lines of e.g. the following form:
+
+```
+SRV1$:0x14:39b5d84478163a2be381859f34c8c8ca41119ce403410223dda828645eea6e97
+SRV1$:0x13:761113c7fcf80cc3286b34a7a866d97f
+SRV1$:aes256-cts-hmac-sha1-96:434c01c7180ba7fdc71f06e1937ee25ac78ea1bb28e381ded419e94e3ad779e0
+SRV1$:aes128-cts-hmac-sha1-96:7ce9f9487c17aaafb507ba8dfe0ea48c
+SRV1$:0x17:c8779d919466485b870aa6eac02b8f03
+```
 
 ## getlocalsid.py
 Uses MS-LSAT RPC to query a host for the SID of it's local domain by translating the NETBIOS domain name to a SID.

--- a/keytab.py
+++ b/keytab.py
@@ -4,102 +4,103 @@ import binascii
 import sys
 
 # Keytab structure from http://www.ioplex.com/utilities/keytab.txt
-  # keytab {
-  #     uint16_t file_format_version;                    /* 0x502 */
-  #     keytab_entry entries[*];
-  # };
+# keytab {
+#     uint16_t file_format_version;                    /* 0x502 */
+#     keytab_entry entries[*];
+# };
 
-  # keytab_entry {
-  #     int32_t size;
-  #     uint16_t num_components;    /* sub 1 if version 0x501 */
-  #     counted_octet_string realm;
-  #     counted_octet_string components[num_components];
-  #     uint32_t name_type;   /* not present if version 0x501 */
-  #     uint32_t timestamp;
-  #     uint8_t vno8;
-  #     keyblock key;
-  #     uint32_t vno; /* only present if >= 4 bytes left in entry */
-  # };
+# keytab_entry {
+#     int32_t size;
+#     uint16_t num_components;    /* sub 1 if version 0x501 */
+#     counted_octet_string realm;
+#     counted_octet_string components[num_components];
+#     uint32_t name_type;   /* not present if version 0x501 */
+#     uint32_t timestamp;
+#     uint8_t vno8;
+#     keyblock key;
+#     uint32_t vno; /* only present if >= 4 bytes left in entry */
+# };
 
-  # counted_octet_string {
-  #     uint16_t length;
-  #     uint8_t data[length];
-  # };
+# counted_octet_string {
+#     uint16_t length;
+#     uint8_t data[length];
+# };
 
-  # keyblock {
-  #     uint16_t type;
-  #     counted_octet_string;
-  # };
+# keyblock {
+#     uint16_t type;
+#     counted_octet_string;
+# };
+
 
 class KeyTab(Structure):
-    structure = (
-        ('file_format_version','H=517'),
-        ('keytab_entry', ':')
-    )
+    structure = (("file_format_version", "H=517"), ("keytab_entry", ":"))
+
     def fromString(self, data):
         self.entries = []
         Structure.fromString(self, data)
-        data = self['keytab_entry']
+        data = self["keytab_entry"]
         while len(data) != 0:
             ktentry = KeyTabEntry(data)
 
-            data = data[len(ktentry.getData()):]
+            data = data[len(ktentry.getData()) :]
             self.entries.append(ktentry)
 
     def getData(self):
-        self['keytab_entry'] = b''.join([entry.getData() for entry in self.entries])
+        self["keytab_entry"] = b"".join([entry.getData() for entry in self.entries])
         data = Structure.getData(self)
         return data
 
+
 class OctetString(Structure):
-    structure = (
-        ('len', '>H-value'),
-        ('value', ':')
-    )
+    structure = (("len", ">H-value"), ("value", ":"))
+
 
 class KeyTabContentRest(Structure):
     structure = (
-        ('name_type', '>I=1'),
-        ('timestamp', '>I=0'),
-        ('vno8', 'B=2'),
-        ('keytype', '>H'),
-        ('keylen', '>H-key'),
-        ('key', ':')
+        ("name_type", ">I=1"),
+        ("timestamp", ">I=0"),
+        ("vno8", "B=2"),
+        ("keytype", ">H"),
+        ("keylen", ">H-key"),
+        ("key", ":"),
     )
+
 
 class KeyTabContent(Structure):
     structure = (
-        ('num_components', '>h'),
-        ('realmlen', '>h-realm'),
-        ('realm', ':'),
-        ('components', ':'),
-        ('restdata',':')
+        ("num_components", ">h"),
+        ("realmlen", ">h-realm"),
+        ("realm", ":"),
+        ("components", ":"),
+        ("restdata", ":"),
     )
+
     def fromString(self, data):
         self.components = []
         Structure.fromString(self, data)
-        data = self['components']
-        for i in range(self['num_components']):
+        data = self["components"]
+        for i in range(self["num_components"]):
             ktentry = OctetString(data)
 
-            data = data[ktentry['len']+2:]
+            data = data[ktentry["len"] + 2 :]
             self.components.append(ktentry)
         self.restfields = KeyTabContentRest(data)
 
     def getData(self):
-        self['num_components'] = len(self.components)
+        self["num_components"] = len(self.components)
         # We modify the data field to be able to use the
         # parent class parsing
-        self['components'] = b''.join([component.getData() for component in self.components])
-        self['restdata'] = self.restfields.getData()
+        self["components"] = b"".join(
+            [component.getData() for component in self.components]
+        )
+        self["restdata"] = self.restfields.getData()
         data = Structure.getData(self)
         return data
 
+
 class KeyTabEntry(Structure):
-    structure = (
-        ('size','>I-content'),
-        ('content',':', KeyTabContent)
-    )
+    structure = (("size", ">I-content"), ("content", ":", KeyTabContent))
+
 
 # Add your own keys here!
 # Keys are tuples in the form (keytype, 'hexencodedkey')
@@ -110,11 +111,11 @@ class KeyTabEntry(Structure):
 # Wireshark takes any number of keys in the keytab, so feel free to add
 # krbtgt keys, service keys, trust keys etc
 keys = [
-    (23, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-    (18, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-    (17, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-    (18, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-    (23, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    (23, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    (18, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    (17, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    (18, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    (23, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 ]
 
 nkt = KeyTab()
@@ -122,23 +123,23 @@ nkt.entries = []
 
 for key in keys:
     ktcr = KeyTabContentRest()
-    ktcr['keytype'] = key[0]
-    ktcr['key'] = binascii.unhexlify(key[1])
+    ktcr["keytype"] = key[0]
+    ktcr["key"] = binascii.unhexlify(key[1])
     nktcontent = KeyTabContent()
     nktcontent.restfields = ktcr
     # The realm here doesn't matter for wireshark but does of course for a real keytab
-    nktcontent['realm'] = b'TESTSEGMENT.LOCAL'
+    nktcontent["realm"] = b"TESTSEGMENT.LOCAL"
     krbtgt = OctetString()
-    krbtgt['value'] = 'krbtgt'
+    krbtgt["value"] = "krbtgt"
     nktcontent.components = [krbtgt]
     nktentry = KeyTabEntry()
-    nktentry['content'] = nktcontent
+    nktentry["content"] = nktcontent
     nkt.entries.append(nktentry)
 
 data = nkt.getData()
 if len(sys.argv) < 2:
-    print('Usage: keytab.py <outputfile>')
-    print('Keys should be written to the source manually')
+    print("Usage: keytab.py <outputfile>")
+    print("Keys should be written to the source manually")
 else:
-    with open(sys.argv[1], 'wb') as outfile:
+    with open(sys.argv[1], "wb") as outfile:
         outfile.write(data)


### PR DESCRIPTION
Hello Dirk-jan, thanks for the great tooling. Recently I also had to analyze Kerberos traffic in Wireshark, and found it useful / a more streamlined workflow to be able to directly convert the output of `impacket-secretsdump` without manual post-processing to a keytab. This pull-request implements this.